### PR TITLE
etcd: Probe VMIs with a TCP socket action on SSH port

### DIFF
--- a/controllers/BUILD.bazel
+++ b/controllers/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_apimachinery//pkg/types",
+        "@io_k8s_apimachinery//pkg/util/intstr",
         "@io_k8s_apimachinery//pkg/util/sets",
         "@io_k8s_client_go//tools/cache",
         "@io_k8s_client_go//util/workqueue",

--- a/controllers/etcd.go
+++ b/controllers/etcd.go
@@ -177,7 +177,7 @@ func probeEtcdMember(
 	status kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (bool, error) {
 	var span trace.Span
-	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcileVirtualMachineInstance")
+	ctx, span = tracing.FromContext(ctx).Start(ctx, "probeEtcdMember")
 	defer span.End()
 	logger := log.FromContext(ctx)
 

--- a/controllers/vm.go
+++ b/controllers/vm.go
@@ -14,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -230,6 +231,9 @@ func reconcileVirtualMachineInstance(
 		k8s_object.WithLabel("app.kubernetes.io/part-of", "etcd"),
 		k8s_object.WithOwner(en, scheme),
 		k8s_vmi.WithUserData(status.UserDataRef),
+		k8s_vmi.WithReadinessTCPProbe(&corev1.TCPSocketAction{
+			Port: intstr.FromInt(serviceContainerPortSSH),
+		}),
 	); err != nil {
 		return nil, fmt.Errorf("unable to create VirtualMachineInstance: %w", err)
 	} else {

--- a/controllers/vm.go
+++ b/controllers/vm.go
@@ -219,12 +219,12 @@ func reconcileVirtualMachineInstance(
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcileVirtualMachineInstance")
 	defer span.End()
 
-	if vmi, err := k8s_vmi.ReconcileVirtualMachineInstance(
+	if vmi, err := k8s_vmi.CreateIfNotExist(
 		ctx,
 		en,
 		c,
-		newVirtualMachineInstanceName(en),
-		en.Namespace,
+		k8s_object.WithName(newVirtualMachineInstanceName(en)),
+		k8s_object.WithNamespace(en.Namespace),
 		k8s_object.WithLabel("app.kubernetes.io/name", "virtualmachineimage"),
 		k8s_object.WithLabel("app.kubernetes.io/instance", newVirtualMachineInstanceName(en)),
 		k8s_object.WithLabel("app.kubernetes.io/part-of", "etcd"),

--- a/controllers/vm.go
+++ b/controllers/vm.go
@@ -114,7 +114,7 @@ func reconcileUserData(
 		return nil, fmt.Errorf("unable to get a service %s/%s: %w", en.Namespace, spec.ServiceRef.Name, err)
 	}
 	if service.Spec.ClusterIP == "" {
-		return nil, NewRequeueError("waiting for a cluster IP of the etcd Service prepared").Wrap(err)
+		return nil, NewRequeueError("waiting for a cluster IP of the etcd Service prepared")
 	}
 
 	var peerService corev1.Service
@@ -132,7 +132,7 @@ func reconcileUserData(
 		return nil, fmt.Errorf("unable to get a peer service %s/%s: %w", en.Namespace, status.PeerServiceRef.Name, err)
 	}
 	if peerService.Spec.ClusterIP == "" {
-		return nil, NewRequeueError("waiting for a cluster IP of the etcd peer Service prepared").Wrap(err)
+		return nil, NewRequeueError("waiting for a cluster IP of the etcd peer Service prepared")
 	}
 
 	startEtcdScriptBuf := bytes.Buffer{}

--- a/controllers/vm.go
+++ b/controllers/vm.go
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-	defaultEtcdadmVersion = "2022.05.22"
+	defaultEtcdadmVersion = "2022.05.31"
 
 	defaultEtcdVersion = "3.5.1"
 )

--- a/k8s/vmi/BUILD.bazel
+++ b/k8s/vmi/BUILD.bazel
@@ -8,12 +8,11 @@ go_library(
     deps = [
         "//k8s/object",
         "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
-        "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/client",
-        "@io_k8s_sigs_controller_runtime//pkg/controller/controllerutil",
         "@io_k8s_sigs_controller_runtime//pkg/log",
         "@io_kubevirt_api//core/v1:core",
     ],

--- a/k8s/vmi/vmi.go
+++ b/k8s/vmi/vmi.go
@@ -108,6 +108,21 @@ func WithUserData(userDataRef *corev1.LocalObjectReference) k8s_object.ObjectOpt
 	}
 }
 
+func WithReadinessTCPProbe(tcpAction *corev1.TCPSocketAction) k8s_object.ObjectOption {
+	return func(o runtime.Object) error {
+		vmi, ok := o.(*kubevirtv1.VirtualMachineInstance)
+		if !ok {
+			return errors.New("not a instance of VirtualMachineInstance")
+		}
+		vmi.Spec.ReadinessProbe = &kubevirtv1.Probe{
+			Handler: kubevirtv1.Handler{
+				TCPSocket: tcpAction,
+			},
+		}
+		return nil
+	}
+}
+
 func CreateIfNotExist(
 	ctx context.Context,
 	owner metav1.Object,


### PR DESCRIPTION
- etcd: Bump the version of etcdadm to v2022.05.31
- fix: Avoid updating a VirtualMachineInstance for an EtcdNode
- fix: Fix a log message
- fix: Don't wrap nil errors
- etcd: Probe VMIs with a TCP socket action on SSH port
