### PR TITLE
refactor: Pass specs and statuses by pointers

### DIFF
--- a/controllers/etcd/endpointslice.go
+++ b/controllers/etcd/endpointslice.go
@@ -30,7 +30,7 @@ func reconcileEndpointSlice(
 	c client.Client,
 	scheme *runtime.Scheme,
 	obj client.Object,
-	_ kubernetesimalv1alpha1.EtcdSpec,
+	_ *kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.LocalObjectReference, error) {
 	var span trace.Span

--- a/controllers/etcd/endpointslice.go
+++ b/controllers/etcd/endpointslice.go
@@ -31,7 +31,7 @@ func reconcileEndpointSlice(
 	scheme *runtime.Scheme,
 	obj client.Object,
 	_ *kubernetesimalv1alpha1.EtcdSpec,
-	status kubernetesimalv1alpha1.EtcdStatus,
+	status *kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.LocalObjectReference, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcileEndpointSlice")

--- a/controllers/etcd/etcd.go
+++ b/controllers/etcd/etcd.go
@@ -23,7 +23,7 @@ func probeEtcd(
 	c client.Client,
 	obj client.Object,
 	_ *kubernetesimalv1alpha1.EtcdSpec,
-	status kubernetesimalv1alpha1.EtcdStatus,
+	status *kubernetesimalv1alpha1.EtcdStatus,
 ) (bool, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "probeEtcd")
@@ -31,20 +31,20 @@ func probeEtcd(
 	logger := log.FromContext(ctx)
 
 	if status.ServiceRef == nil {
-		logger.Info("a Service for an etcd is not prepared yet")
+		logger.V(4).Info("a Service for an etcd is not prepared yet")
 		return false, nil
 	}
 	address, err := k8s_service.GetAddressFromServiceRef(ctx, c, obj.GetNamespace(), "etcd", status.ServiceRef)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("Skip probing an etcd since an etcd Service isn't prepared yet.")
+			logger.V(4).Info("Skip probing an etcd since an etcd Service isn't prepared yet.")
 			return false, nil
 		}
 		return false, fmt.Errorf("unable to get an etcd address from an etcd Service: %w", err)
 	}
 
 	if status.CACertificateRef == nil {
-		logger.Info("a CA certificate for an etcd Service is not prepared yet")
+		logger.V(4).Info("a CA certificate for an etcd Service is not prepared yet")
 		return false, nil
 	}
 	caCertificate, err := k8s_secret.GetValueFromSecretKeySelector(
@@ -55,7 +55,7 @@ func probeEtcd(
 	)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("Skip probing an etcd since CA certificate isn't prepared yet.")
+			logger.V(4).Info("Skip probing an etcd since CA certificate isn't prepared yet.")
 			return false, nil
 		}
 		return false, fmt.Errorf("unable to get a CA certificate: %w", err)
@@ -97,7 +97,7 @@ func probeEtcd(
 	)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("Skip probing an etcd since a client private key isn't prepared yet.")
+			logger.V(4).Info("Skip probing an etcd since a client private key isn't prepared yet.")
 			return false, nil
 		}
 		return false, fmt.Errorf("unable to get a client private key: %w", err)

--- a/controllers/etcd/etcd.go
+++ b/controllers/etcd/etcd.go
@@ -21,7 +21,7 @@ import (
 func probeEtcd(
 	ctx context.Context,
 	c client.Client,
-	e *kubernetesimalv1alpha1.Etcd,
+	obj client.Object,
 	spec kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (bool, error) {
@@ -34,7 +34,7 @@ func probeEtcd(
 		logger.Info("a Service for an etcd is not prepared yet")
 		return false, nil
 	}
-	address, err := k8s_service.GetAddressFromServiceRef(ctx, c, e.Namespace, "etcd", status.ServiceRef)
+	address, err := k8s_service.GetAddressFromServiceRef(ctx, c, obj.GetNamespace(), "etcd", status.ServiceRef)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("Skip probing an etcd since an etcd Service isn't prepared yet.")
@@ -50,7 +50,7 @@ func probeEtcd(
 	caCertificate, err := k8s_secret.GetValueFromSecretKeySelector(
 		ctx,
 		c,
-		e.Namespace,
+		obj.GetNamespace(),
 		*status.CACertificateRef,
 	)
 	if err != nil {
@@ -75,7 +75,7 @@ func probeEtcd(
 	clientCertificate, err := k8s_secret.GetValueFromSecretKeySelector(
 		ctx,
 		c,
-		e.Namespace,
+		obj.GetNamespace(),
 		*status.ClientCertificateRef,
 	)
 	if err != nil {
@@ -92,7 +92,7 @@ func probeEtcd(
 	clientPrivateKey, err := k8s_secret.GetValueFromSecretKeySelector(
 		ctx,
 		c,
-		e.Namespace,
+		obj.GetNamespace(),
 		*status.ClientPrivateKeyRef,
 	)
 	if err != nil {

--- a/controllers/etcd/etcd.go
+++ b/controllers/etcd/etcd.go
@@ -22,7 +22,7 @@ func probeEtcd(
 	ctx context.Context,
 	c client.Client,
 	obj client.Object,
-	spec kubernetesimalv1alpha1.EtcdSpec,
+	_ *kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (bool, error) {
 	var span trace.Span

--- a/controllers/etcd/etcdnode.go
+++ b/controllers/etcd/etcdnode.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kkohtaka/kubernetesimal/controller/finalizer"
 	"github.com/kkohtaka/kubernetesimal/observability/tracing"
 	"go.opentelemetry.io/otel/trace"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -15,7 +14,7 @@ import (
 func finalizeEtcdNodes(
 	ctx context.Context,
 	c client.Client,
-	e metav1.Object,
+	e client.Object,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (kubernetesimalv1alpha1.EtcdStatus, error) {
 	var span trace.Span

--- a/controllers/etcd/etcdnode.go
+++ b/controllers/etcd/etcdnode.go
@@ -15,8 +15,8 @@ func finalizeEtcdNodes(
 	ctx context.Context,
 	c client.Client,
 	e client.Object,
-	status kubernetesimalv1alpha1.EtcdStatus,
-) (kubernetesimalv1alpha1.EtcdStatus, error) {
+	status *kubernetesimalv1alpha1.EtcdStatus,
+) (*kubernetesimalv1alpha1.EtcdStatus, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "finalizeEtcdNode")
 	defer span.End()

--- a/controllers/etcd/pki.go
+++ b/controllers/etcd/pki.go
@@ -35,7 +35,7 @@ func reconcileCACertificate(
 	scheme *runtime.Scheme,
 	obj client.Object,
 	_ *kubernetesimalv1alpha1.EtcdSpec,
-	status kubernetesimalv1alpha1.EtcdStatus,
+	status *kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.SecretKeySelector, *corev1.SecretKeySelector, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcileCACertificate")
@@ -108,8 +108,8 @@ func finalizeCACertificateSecret(
 	ctx context.Context,
 	c client.Client,
 	obj client.Object,
-	status kubernetesimalv1alpha1.EtcdStatus,
-) (kubernetesimalv1alpha1.EtcdStatus, error) {
+	status *kubernetesimalv1alpha1.EtcdStatus,
+) (*kubernetesimalv1alpha1.EtcdStatus, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "finalizeCACertificateSecret")
 	defer span.End()
@@ -139,7 +139,7 @@ func reconcileClientCertificate(
 	scheme *runtime.Scheme,
 	obj client.Object,
 	_ *kubernetesimalv1alpha1.EtcdSpec,
-	status kubernetesimalv1alpha1.EtcdStatus,
+	status *kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.SecretKeySelector, *corev1.SecretKeySelector, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcileClientCertificate")
@@ -244,7 +244,7 @@ func reconcilePeerCertificate(
 	scheme *runtime.Scheme,
 	obj client.Object,
 	_ *kubernetesimalv1alpha1.EtcdSpec,
-	status kubernetesimalv1alpha1.EtcdStatus,
+	status *kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.SecretKeySelector, *corev1.SecretKeySelector, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcilePeerCertificate")
@@ -347,8 +347,8 @@ func finalizeClientCertificateSecret(
 	ctx context.Context,
 	c client.Client,
 	obj client.Object,
-	status kubernetesimalv1alpha1.EtcdStatus,
-) (kubernetesimalv1alpha1.EtcdStatus, error) {
+	status *kubernetesimalv1alpha1.EtcdStatus,
+) (*kubernetesimalv1alpha1.EtcdStatus, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "finalizeClientCertificateSecret")
 	defer span.End()
@@ -368,8 +368,8 @@ func finalizePeerCertificateSecret(
 	ctx context.Context,
 	c client.Client,
 	obj client.Object,
-	status kubernetesimalv1alpha1.EtcdStatus,
-) (kubernetesimalv1alpha1.EtcdStatus, error) {
+	status *kubernetesimalv1alpha1.EtcdStatus,
+) (*kubernetesimalv1alpha1.EtcdStatus, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "finalizePeerCertificateSecret")
 	defer span.End()

--- a/controllers/etcd/pki.go
+++ b/controllers/etcd/pki.go
@@ -34,7 +34,7 @@ func reconcileCACertificate(
 	c client.Client,
 	scheme *runtime.Scheme,
 	obj client.Object,
-	_ kubernetesimalv1alpha1.EtcdSpec,
+	_ *kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.SecretKeySelector, *corev1.SecretKeySelector, error) {
 	var span trace.Span
@@ -138,7 +138,7 @@ func reconcileClientCertificate(
 	c client.Client,
 	scheme *runtime.Scheme,
 	obj client.Object,
-	_ kubernetesimalv1alpha1.EtcdSpec,
+	_ *kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.SecretKeySelector, *corev1.SecretKeySelector, error) {
 	var span trace.Span
@@ -243,7 +243,7 @@ func reconcilePeerCertificate(
 	c client.Client,
 	scheme *runtime.Scheme,
 	obj client.Object,
-	_ kubernetesimalv1alpha1.EtcdSpec,
+	_ *kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.SecretKeySelector, *corev1.SecretKeySelector, error) {
 	var span trace.Span

--- a/controllers/etcd/prober.go
+++ b/controllers/etcd/prober.go
@@ -80,7 +80,7 @@ func (r *Prober) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 
 func (r *Prober) doReconcile(
 	ctx context.Context,
-	e *kubernetesimalv1alpha1.Etcd,
+	obj client.Object,
 	spec kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (kubernetesimalv1alpha1.EtcdStatus, error) {
@@ -88,11 +88,11 @@ func (r *Prober) doReconcile(
 	defer span.End()
 	logger := log.FromContext(ctx)
 
-	if !e.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !obj.GetDeletionTimestamp().IsZero() {
 		return status, nil
 	}
 
-	if probed, err := probeEtcd(ctx, r.Client, e, spec, status); err != nil {
+	if probed, err := probeEtcd(ctx, r.Client, obj, spec, status); err != nil {
 		status.WithReady(false, err.Error()).DeepCopyInto(&status)
 		return status, fmt.Errorf("unable to probe an etcd: %w", err)
 	} else {

--- a/controllers/etcd/prober.go
+++ b/controllers/etcd/prober.go
@@ -67,7 +67,7 @@ func (r *Prober) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 		return ctrl.Result{}, err
 	}
 
-	status, err := r.doReconcile(ctx, &e, e.Spec, e.Status)
+	status, err := r.doReconcile(ctx, &e, e.Spec.DeepCopy(), e.Status)
 	if statusUpdateErr := r.updateStatus(ctx, &e, status); statusUpdateErr != nil {
 		logger.Error(statusUpdateErr, "unable to update a status of an object")
 		return ctrl.Result{}, statusUpdateErr
@@ -81,7 +81,7 @@ func (r *Prober) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 func (r *Prober) doReconcile(
 	ctx context.Context,
 	obj client.Object,
-	spec kubernetesimalv1alpha1.EtcdSpec,
+	spec *kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (kubernetesimalv1alpha1.EtcdStatus, error) {
 	ctx, span := tracing.FromContext(ctx).Start(ctx, "doReconcile")

--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -85,7 +85,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	status, err := r.doReconcile(ctx, &e, e.Spec, e.Status)
+	status, err := r.doReconcile(ctx, &e, e.Spec.DeepCopy(), e.Status)
 	if statusUpdateErr := r.updateStatus(ctx, &e, status); statusUpdateErr != nil {
 		logger.Error(statusUpdateErr, "unable to update a status of an object")
 	}
@@ -109,7 +109,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) doReconcile(
 	ctx context.Context,
 	obj client.Object,
-	spec kubernetesimalv1alpha1.EtcdSpec,
+	spec *kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (kubernetesimalv1alpha1.EtcdStatus, error) {
 	ctx, span := tracing.FromContext(ctx).Start(ctx, "doReconcile")
@@ -197,7 +197,7 @@ func (r *Reconciler) finalizeExternalResources(
 func (r *Reconciler) reconcileExternalResources(
 	ctx context.Context,
 	obj client.Object,
-	spec kubernetesimalv1alpha1.EtcdSpec,
+	spec *kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (kubernetesimalv1alpha1.EtcdStatus, error) {
 	var span trace.Span

--- a/controllers/etcd/service.go
+++ b/controllers/etcd/service.go
@@ -32,7 +32,7 @@ func reconcileService(
 	c client.Client,
 	scheme *runtime.Scheme,
 	obj client.Object,
-	_ kubernetesimalv1alpha1.EtcdSpec,
+	_ *kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.LocalObjectReference, error) {
 	var span trace.Span

--- a/controllers/etcd/service.go
+++ b/controllers/etcd/service.go
@@ -6,7 +6,6 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -24,15 +23,15 @@ const (
 	ServiceContainerPortEtcd = 2379
 )
 
-func newServiceName(e metav1.Object) string {
-	return e.GetName()
+func newServiceName(obj client.Object) string {
+	return obj.GetName()
 }
 
 func reconcileService(
 	ctx context.Context,
 	c client.Client,
 	scheme *runtime.Scheme,
-	e metav1.Object,
+	obj client.Object,
 	_ kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.LocalObjectReference, error) {
@@ -42,11 +41,11 @@ func reconcileService(
 
 	if service, err := k8s_service.Reconcile(
 		ctx,
-		e,
+		obj,
 		c,
-		newServiceName(e),
-		e.GetNamespace(),
-		k8s_object.WithOwner(e, scheme),
+		newServiceName(obj),
+		obj.GetNamespace(),
+		k8s_object.WithOwner(obj, scheme),
 		k8s_service.WithType(corev1.ServiceTypeNodePort),
 		k8s_service.WithPort(ServiceNameEtcd, ServicePortEtcd, ServiceContainerPortEtcd),
 	); err != nil {

--- a/controllers/etcd/service.go
+++ b/controllers/etcd/service.go
@@ -33,7 +33,7 @@ func reconcileService(
 	scheme *runtime.Scheme,
 	obj client.Object,
 	_ *kubernetesimalv1alpha1.EtcdSpec,
-	status kubernetesimalv1alpha1.EtcdStatus,
+	status *kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.LocalObjectReference, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcileService")

--- a/controllers/etcd/ssh.go
+++ b/controllers/etcd/ssh.go
@@ -34,7 +34,7 @@ func reconcileSSHKeyPair(
 	scheme *runtime.Scheme,
 	obj client.Object,
 	_ *kubernetesimalv1alpha1.EtcdSpec,
-	status kubernetesimalv1alpha1.EtcdStatus,
+	status *kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.SecretKeySelector, *corev1.SecretKeySelector, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcileSSHKeyPair")
@@ -107,8 +107,8 @@ func finalizeSSHKeyPairSecret(
 	ctx context.Context,
 	c client.Client,
 	obj client.Object,
-	status kubernetesimalv1alpha1.EtcdStatus,
-) (kubernetesimalv1alpha1.EtcdStatus, error) {
+	status *kubernetesimalv1alpha1.EtcdStatus,
+) (*kubernetesimalv1alpha1.EtcdStatus, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "finalizeSSHKeyPairSecret")
 	defer span.End()

--- a/controllers/etcd/ssh.go
+++ b/controllers/etcd/ssh.go
@@ -33,7 +33,7 @@ func reconcileSSHKeyPair(
 	c client.Client,
 	scheme *runtime.Scheme,
 	obj client.Object,
-	_ kubernetesimalv1alpha1.EtcdSpec,
+	_ *kubernetesimalv1alpha1.EtcdSpec,
 	status kubernetesimalv1alpha1.EtcdStatus,
 ) (*corev1.SecretKeySelector, *corev1.SecretKeySelector, error) {
 	var span trace.Span

--- a/controllers/etcdnode/BUILD.bazel
+++ b/controllers/etcdnode/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/equality",
         "@io_k8s_apimachinery//pkg/api/errors",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_apimachinery//pkg/types",
         "@io_k8s_apimachinery//pkg/util/intstr",

--- a/controllers/etcdnode/etcd.go
+++ b/controllers/etcdnode/etcd.go
@@ -29,7 +29,7 @@ func provisionEtcdMember(
 	c client.Client,
 	obj client.Object,
 	spec *kubernetesimalv1alpha1.EtcdNodeSpec,
-	status kubernetesimalv1alpha1.EtcdNodeStatus,
+	status *kubernetesimalv1alpha1.EtcdNodeStatus,
 ) error {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "provisionEtcdMember")
@@ -117,7 +117,7 @@ func probeEtcdMember(
 	c client.Client,
 	obj client.Object,
 	spec *kubernetesimalv1alpha1.EtcdNodeSpec,
-	status kubernetesimalv1alpha1.EtcdNodeStatus,
+	status *kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (bool, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "probeEtcdMember")

--- a/controllers/etcdnode/etcd.go
+++ b/controllers/etcdnode/etcd.go
@@ -28,7 +28,7 @@ func provisionEtcdMember(
 	ctx context.Context,
 	c client.Client,
 	obj client.Object,
-	spec kubernetesimalv1alpha1.EtcdNodeSpec,
+	spec *kubernetesimalv1alpha1.EtcdNodeSpec,
 	status kubernetesimalv1alpha1.EtcdNodeStatus,
 ) error {
 	var span trace.Span
@@ -116,7 +116,7 @@ func probeEtcdMember(
 	ctx context.Context,
 	c client.Client,
 	obj client.Object,
-	spec kubernetesimalv1alpha1.EtcdNodeSpec,
+	spec *kubernetesimalv1alpha1.EtcdNodeSpec,
 	status kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (bool, error) {
 	var span trace.Span

--- a/controllers/etcdnode/prober.go
+++ b/controllers/etcdnode/prober.go
@@ -67,7 +67,7 @@ func (r *Prober) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 		return ctrl.Result{}, err
 	}
 
-	status, err := r.doReconcile(ctx, &en, en.Spec, en.Status)
+	status, err := r.doReconcile(ctx, &en, en.Spec.DeepCopy(), en.Status)
 	if statusUpdateErr := r.updateStatus(ctx, &en, status); statusUpdateErr != nil {
 		logger.Error(statusUpdateErr, "unable to update a status of an object")
 		return ctrl.Result{}, statusUpdateErr
@@ -81,7 +81,7 @@ func (r *Prober) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 func (r *Prober) doReconcile(
 	ctx context.Context,
 	obj client.Object,
-	spec kubernetesimalv1alpha1.EtcdNodeSpec,
+	spec *kubernetesimalv1alpha1.EtcdNodeSpec,
 	status kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (kubernetesimalv1alpha1.EtcdNodeStatus, error) {
 	ctx, span := tracing.FromContext(ctx).Start(ctx, "doReconcile")

--- a/controllers/etcdnode/prober.go
+++ b/controllers/etcdnode/prober.go
@@ -80,7 +80,7 @@ func (r *Prober) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 
 func (r *Prober) doReconcile(
 	ctx context.Context,
-	en *kubernetesimalv1alpha1.EtcdNode,
+	obj client.Object,
 	spec kubernetesimalv1alpha1.EtcdNodeSpec,
 	status kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (kubernetesimalv1alpha1.EtcdNodeStatus, error) {
@@ -88,7 +88,7 @@ func (r *Prober) doReconcile(
 	defer span.End()
 	logger := log.FromContext(ctx)
 
-	if !en.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !obj.GetDeletionTimestamp().IsZero() {
 		return status, nil
 	}
 
@@ -96,7 +96,7 @@ func (r *Prober) doReconcile(
 		return status, nil
 	}
 
-	if probed, err := probeEtcdMember(ctx, r.Client, en, spec, status); err != nil {
+	if probed, err := probeEtcdMember(ctx, r.Client, obj, spec, status); err != nil {
 		status.WithReady(false, err.Error()).DeepCopyInto(&status)
 		return status, fmt.Errorf("unable to probe an etcd member: %w", err)
 	} else {

--- a/controllers/etcdnode/reconciler.go
+++ b/controllers/etcdnode/reconciler.go
@@ -69,7 +69,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	status, err := r.doReconcile(ctx, &en, en.Spec, en.Status)
+	status, err := r.doReconcile(ctx, &en, en.Spec.DeepCopy(), en.Status)
 	if statusUpdateErr := r.updateStatus(ctx, &en, status); statusUpdateErr != nil {
 		logger.Error(statusUpdateErr, "unable to update a status of an object")
 	}
@@ -93,7 +93,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) doReconcile(
 	ctx context.Context,
 	obj client.Object,
-	spec kubernetesimalv1alpha1.EtcdNodeSpec,
+	spec *kubernetesimalv1alpha1.EtcdNodeSpec,
 	status kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (kubernetesimalv1alpha1.EtcdNodeStatus, error) {
 	ctx, span := tracing.FromContext(ctx).Start(ctx, "doReconcile")
@@ -157,7 +157,7 @@ func (r *Reconciler) finalizeExternalResources(
 func (r *Reconciler) reconcileExternalResources(
 	ctx context.Context,
 	obj client.Object,
-	spec kubernetesimalv1alpha1.EtcdNodeSpec,
+	spec *kubernetesimalv1alpha1.EtcdNodeSpec,
 	status kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (kubernetesimalv1alpha1.EtcdNodeStatus, error) {
 	var span trace.Span

--- a/controllers/etcdnode/service.go
+++ b/controllers/etcdnode/service.go
@@ -39,7 +39,7 @@ func reconcilePeerService(
 	scheme *runtime.Scheme,
 	obj client.Object,
 	_ *kubernetesimalv1alpha1.EtcdNodeSpec,
-	status kubernetesimalv1alpha1.EtcdNodeStatus,
+	_ *kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (*corev1.LocalObjectReference, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcileService")

--- a/controllers/etcdnode/service.go
+++ b/controllers/etcdnode/service.go
@@ -38,7 +38,7 @@ func reconcilePeerService(
 	c client.Client,
 	scheme *runtime.Scheme,
 	obj client.Object,
-	_ kubernetesimalv1alpha1.EtcdNodeSpec,
+	_ *kubernetesimalv1alpha1.EtcdNodeSpec,
 	status kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (*corev1.LocalObjectReference, error) {
 	var span trace.Span

--- a/controllers/etcdnode/vm.go
+++ b/controllers/etcdnode/vm.go
@@ -56,7 +56,7 @@ func reconcileUserData(
 	c client.Client,
 	scheme *runtime.Scheme,
 	obj client.Object,
-	spec kubernetesimalv1alpha1.EtcdNodeSpec,
+	spec *kubernetesimalv1alpha1.EtcdNodeSpec,
 	status kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (*corev1.LocalObjectReference, error) {
 	var span trace.Span
@@ -223,7 +223,7 @@ func reconcileVirtualMachineInstance(
 	c client.Client,
 	scheme *runtime.Scheme,
 	obj client.Object,
-	_ kubernetesimalv1alpha1.EtcdNodeSpec,
+	_ *kubernetesimalv1alpha1.EtcdNodeSpec,
 	status kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (*corev1.LocalObjectReference, error) {
 	var span trace.Span

--- a/controllers/etcdnode/vm.go
+++ b/controllers/etcdnode/vm.go
@@ -57,7 +57,7 @@ func reconcileUserData(
 	scheme *runtime.Scheme,
 	obj client.Object,
 	spec *kubernetesimalv1alpha1.EtcdNodeSpec,
-	status kubernetesimalv1alpha1.EtcdNodeStatus,
+	status *kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (*corev1.LocalObjectReference, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcileUserData")
@@ -224,7 +224,7 @@ func reconcileVirtualMachineInstance(
 	scheme *runtime.Scheme,
 	obj client.Object,
 	_ *kubernetesimalv1alpha1.EtcdNodeSpec,
-	status kubernetesimalv1alpha1.EtcdNodeStatus,
+	status *kubernetesimalv1alpha1.EtcdNodeStatus,
 ) (*corev1.LocalObjectReference, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "reconcileVirtualMachineInstance")
@@ -257,8 +257,8 @@ func finalizeVirtualMachineInstance(
 	ctx context.Context,
 	client client.Client,
 	obj client.Object,
-	status kubernetesimalv1alpha1.EtcdNodeStatus,
-) (kubernetesimalv1alpha1.EtcdNodeStatus, error) {
+	status *kubernetesimalv1alpha1.EtcdNodeStatus,
+) (*kubernetesimalv1alpha1.EtcdNodeStatus, error) {
 	var span trace.Span
 	ctx, span = tracing.FromContext(ctx).Start(ctx, "finalizeVirtualMachineInstance")
 	defer span.End()


### PR DESCRIPTION
- refactor: Pass client.Object instead of CRD pointers
- refactor: Pass CRD specs by pointers
- refactor: Pass CRD statuses by pointers
