### PR TITLE
fix: Avoid unnecessary continuous probing

### DIFF
--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -138,6 +138,15 @@ func init() {
 	SchemeBuilder.Register(&Etcd{}, &EtcdList{})
 }
 
+func (status *EtcdStatus) LastReadyProbeTime() *metav1.Time {
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == EtcdConditionTypeReady {
+			return status.Conditions[i].LastProbeTime
+		}
+	}
+	return nil
+}
+
 func (status *EtcdStatus) IsReady() bool {
 	for i := range status.Conditions {
 		if status.Conditions[i].Type == EtcdConditionTypeReady {

--- a/api/v1alpha1/etcdnode_types.go
+++ b/api/v1alpha1/etcdnode_types.go
@@ -134,6 +134,15 @@ func init() {
 	SchemeBuilder.Register(&EtcdNode{}, &EtcdNodeList{})
 }
 
+func (status *EtcdNodeStatus) LastReadyProbeTime() *metav1.Time {
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == EtcdNodeConditionTypeReady {
+			return status.Conditions[i].LastProbeTime
+		}
+	}
+	return nil
+}
+
 func (status *EtcdNodeStatus) IsProvisioned() bool {
 	for i := range status.Conditions {
 		if status.Conditions[i].Type == EtcdNodeConditionTypeProvisioned {

--- a/controllers/etcd/BUILD.bazel
+++ b/controllers/etcd/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pki",
         "//ssh",
         "@io_k8s_api//core/v1:core",
+        "@io_k8s_api//discovery/v1:discovery",
         "@io_k8s_api//discovery/v1beta1",
         "@io_k8s_apimachinery//pkg/api/equality",
         "@io_k8s_apimachinery//pkg/api/errors",

--- a/controllers/etcd/endpointslice.go
+++ b/controllers/etcd/endpointslice.go
@@ -6,7 +6,7 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,7 +53,7 @@ func reconcileEndpointSlice(
 		return nil, err
 	}
 
-	var endpoints []discoveryv1beta1.Endpoint
+	var endpoints []discoveryv1.Endpoint
 	for _, ref := range status.NodeRefs {
 		var (
 			node    kubernetesimalv1alpha1.EtcdNode
@@ -117,10 +117,10 @@ func reconcileEndpointSlice(
 			ready       = serving && !terminating
 		)
 
-		endpoints = append(endpoints, discoveryv1beta1.Endpoint{
+		endpoints = append(endpoints, discoveryv1.Endpoint{
 			Addresses: peerService.Spec.ClusterIPs,
 			Hostname:  pointerutils.StringPtr(peerService.Name),
-			Conditions: discoveryv1beta1.EndpointConditions{
+			Conditions: discoveryv1.EndpointConditions{
 				Ready:       &ready,
 				Serving:     &serving,
 				Terminating: &terminating,
@@ -144,7 +144,7 @@ func reconcileEndpointSlice(
 		k8s_object.WithOwner(obj, scheme),
 		k8s_object.WithLabel("kubernetes.io/service-name", service.Name),
 		k8s_object.WithLabel("endpointslice.kubernetes.io/managed-by", "etcd-controller.kubernetesimal.kkohtaka.org"),
-		k8s_endpointslice.WithAddressType(discoveryv1beta1.AddressTypeIPv4),
+		k8s_endpointslice.WithAddressType(discoveryv1.AddressTypeIPv4),
 		k8s_endpointslice.WithPort(ServiceNameEtcd, ServicePortEtcd),
 		k8s_endpointslice.WithEndpoints(endpoints),
 	); err != nil {

--- a/controllers/etcd/prober.go
+++ b/controllers/etcd/prober.go
@@ -30,11 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kubernetesimalv1alpha1 "github.com/kkohtaka/kubernetesimal/api/v1alpha1"
+	"github.com/kkohtaka/kubernetesimal/controller/errors"
 	"github.com/kkohtaka/kubernetesimal/observability/tracing"
-)
-
-const (
-	probeInterval = 5 * time.Second
 )
 
 // Prober reconciles a EtcdNode object
@@ -73,9 +70,20 @@ func (r *Prober) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 		return ctrl.Result{}, statusUpdateErr
 	}
 	if err != nil {
-		return ctrl.Result{}, err
+		if errors.ShouldRequeue(err) {
+			delay := errors.GetDelay(err)
+			logger.Info(
+				"Reconciliation will be requeued.",
+				"reason", err,
+				"delay", delay,
+			)
+			return ctrl.Result{
+				RequeueAfter: delay,
+			}, nil
+		}
+		logger.Error(err, "unable to process probing")
 	}
-	return ctrl.Result{RequeueAfter: probeInterval}, nil
+	return ctrl.Result{RequeueAfter: getProbeInterval(status)}, nil
 }
 
 func (r *Prober) doReconcile(
@@ -89,7 +97,16 @@ func (r *Prober) doReconcile(
 	logger := log.FromContext(ctx)
 
 	if !obj.GetDeletionTimestamp().IsZero() {
+		logger.V(4).Info("Etcd is being deleted")
 		return status, nil
+	}
+
+	if probeTime := status.LastReadyProbeTime(); probeTime != nil {
+		interval := getProbeInterval(status)
+		if time.Since(probeTime.Time) < interval {
+			return status, errors.NewRequeueError("the object was probed within the last probe interval").
+				WithDelay(interval - time.Since(probeTime.Time))
+		}
 	}
 
 	if probed, err := probeEtcd(ctx, r.Client, obj, spec, status); err != nil {
@@ -133,4 +150,16 @@ func (r *Prober) SetupWithManager(mgr ctrl.Manager) error {
 		Named("etcd-prober").
 		For(&kubernetesimalv1alpha1.Etcd{}).
 		Complete(r)
+}
+
+func getProbeInterval(status *kubernetesimalv1alpha1.EtcdStatus) time.Duration {
+	const (
+		probeIntervalOnNotReady = 5 * time.Second
+		probeInterval           = 3 * time.Minute
+	)
+
+	if !status.IsReady() {
+		return probeIntervalOnNotReady
+	}
+	return probeInterval
 }

--- a/controllers/etcd/prober.go
+++ b/controllers/etcd/prober.go
@@ -72,7 +72,7 @@ func (r *Prober) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 	if err != nil {
 		if errors.ShouldRequeue(err) {
 			delay := errors.GetDelay(err)
-			logger.Info(
+			logger.V(2).Info(
 				"Reconciliation will be requeued.",
 				"reason", err,
 				"delay", delay,

--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -92,7 +92,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		if errors.ShouldRequeue(err) {
 			delay := errors.GetDelay(err)
-			logger.Info(
+			logger.V(2).Info(
 				"Reconciliation will be requeued.",
 				"reason", err,
 				"delay", delay,

--- a/controllers/etcdnode/prober.go
+++ b/controllers/etcdnode/prober.go
@@ -72,7 +72,7 @@ func (r *Prober) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 	if err != nil {
 		if errors.ShouldRequeue(err) {
 			delay := errors.GetDelay(err)
-			logger.Info(
+			logger.V(2).Info(
 				"Reconciliation will be requeued.",
 				"reason", err,
 				"delay", delay,

--- a/controllers/etcdnode/reconciler.go
+++ b/controllers/etcdnode/reconciler.go
@@ -76,7 +76,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		if errors.ShouldRequeue(err) {
 			delay := errors.GetDelay(err)
-			logger.Info(
+			logger.V(2).Info(
 				"Reconciliation will be requeued.",
 				"reason", err,
 				"delay", delay,

--- a/k8s/endpointslice/BUILD.bazel
+++ b/k8s/endpointslice/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//k8s/object",
-        "@io_k8s_api//discovery/v1beta1",
+        "@io_k8s_api//discovery/v1:discovery",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",

--- a/k8s/endpointslice/endpointslice.go
+++ b/k8s/endpointslice/endpointslice.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	pointerutils "k8s.io/utils/pointer"
@@ -17,9 +17,9 @@ import (
 	k8s_object "github.com/kkohtaka/kubernetesimal/k8s/object"
 )
 
-func WithAddressType(addressType discoveryv1beta1.AddressType) k8s_object.ObjectOption {
+func WithAddressType(addressType discoveryv1.AddressType) k8s_object.ObjectOption {
 	return func(o runtime.Object) error {
-		ep, ok := o.(*discoveryv1beta1.EndpointSlice)
+		ep, ok := o.(*discoveryv1.EndpointSlice)
 		if !ok {
 			return errors.New("not a instance of EndpointSlice")
 		}
@@ -30,7 +30,7 @@ func WithAddressType(addressType discoveryv1beta1.AddressType) k8s_object.Object
 
 func WithPort(name string, port int32) k8s_object.ObjectOption {
 	return func(o runtime.Object) error {
-		ep, ok := o.(*discoveryv1beta1.EndpointSlice)
+		ep, ok := o.(*discoveryv1.EndpointSlice)
 		if !ok {
 			return errors.New("not a instance of EndpointSlice")
 		}
@@ -40,7 +40,7 @@ func WithPort(name string, port int32) k8s_object.ObjectOption {
 				return nil
 			}
 		}
-		ep.Ports = append(ep.Ports, discoveryv1beta1.EndpointPort{
+		ep.Ports = append(ep.Ports, discoveryv1.EndpointPort{
 			Name: pointerutils.StringPtr(name),
 			Port: pointerutils.Int32(port),
 		})
@@ -48,9 +48,9 @@ func WithPort(name string, port int32) k8s_object.ObjectOption {
 	}
 }
 
-func WithEndpoints(endpoints []discoveryv1beta1.Endpoint) k8s_object.ObjectOption {
+func WithEndpoints(endpoints []discoveryv1.Endpoint) k8s_object.ObjectOption {
 	return func(o runtime.Object) error {
-		ep, ok := o.(*discoveryv1beta1.EndpointSlice)
+		ep, ok := o.(*discoveryv1.EndpointSlice)
 		if !ok {
 			return errors.New("not a instance of EndpointSlice")
 		}
@@ -65,8 +65,8 @@ func Reconcile(
 	c client.Client,
 	name, namespace string,
 	opts ...k8s_object.ObjectOption,
-) (*discoveryv1beta1.EndpointSlice, error) {
-	var endpointSlice discoveryv1beta1.EndpointSlice
+) (*discoveryv1.EndpointSlice, error) {
+	var endpointSlice discoveryv1.EndpointSlice
 	endpointSlice.Name = name
 	endpointSlice.Namespace = namespace
 	opRes, err := ctrl.CreateOrUpdate(ctx, c, &endpointSlice, func() error {


### PR DESCRIPTION
- fix: Avoid unnecessary continuous probing
- *: Use discovery/v1.EndpointSlice instead of v1beta1
- *: Fix log level on printing a message for requeueing
